### PR TITLE
Add disableLoading option

### DIFF
--- a/examples/advanced/disable.html
+++ b/examples/advanced/disable.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Add to home</title>
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0">
+
+	<!-- Of course it is advisable to have touch icons ready for each device -->
+	<link rel="apple-touch-icon" href="touch-icon-iphone.png">
+	<link rel="apple-touch-icon" sizes="72x72" href="touch-icon-ipad.png">
+	<link rel="apple-touch-icon" sizes="114x114" href="touch-icon-iphone4.png">
+
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="black">
+
+	<script type="text/javascript">
+		var addToHomeConfig = {
+			touchIcon:true
+		};
+		// Disable loading of ballon if not on start page or if device is an iPad
+		if (window.location.pathname != '/' || (/ipad/gi).test(navigator.platform)) {
+			addToHomeConfig.disableLoading = true;
+		};	
+
+	</script>
+	<link rel="stylesheet" href="../../style/add2home.css">
+	<script type="application/javascript" src="../../src/add2home.js" charset="utf-8"></script>
+</head>
+
+<body>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+	<p>scroll</p>
+</body>
+</html>

--- a/src/add2home.js
+++ b/src/add2home.js
@@ -25,6 +25,7 @@ var nav = navigator,
 		bottomOffset: 14,			// Distance of the balloon from bottom
 		expire: 0,					// Minutes to wait before showing the popup again (0 = always displayed)
 		message: '',				// Customize your message or force a language ('' = automatic)
+		disableLoading: false,		// Disable loading of balloon
 		touchIcon: false,			// Display the touch icon
 		arrow: true,				// Display the balloon arrow
 		iterations:100				// Internal/debug use
@@ -72,7 +73,7 @@ if (!options.expire || expired < new Date().getTime()) {
 }
 
 /* Bootstrap */
-if (hasHomescreen && !expired && !isStandalone && isSafari) {
+if (hasHomescreen && !expired && !isStandalone && isSafari && !options.disableLoading) {
 	document.addEventListener('DOMContentLoaded', ready, false);
 	window.addEventListener('load', loaded, false);
 }


### PR DESCRIPTION
Added a new option that disables loading of the balloon. Allows the script file to be loaded on all pages but not displaying the balloon on some pages by setting the option. Can of course also be used do disable the balloon based on other criteria, like for example device type.

Includes a new example file showing how it can be used.
