### PR TITLE
Fix error on close when the popup has not been displayed

### DIFF
--- a/src/add2home.js
+++ b/src/add2home.js
@@ -243,6 +243,11 @@ var addToHome = (function (w) {
 		clearTimeout( closeTimeout );
 		closeTimeout = null;
 
+		// check if the popup is displayed and prevent errors
+		if (!balloon){
+            return null;
+        }
+
 		var posY = 0,
 			posX = 0,
 			opacity = '1',


### PR DESCRIPTION
Hi,

This is just a micro fix to prevent that a error occur (l.255) when we try to call "close" function while the popup has not been displayed before.

Best regards.
