### PR TITLE
Native iOS 6 Smart App Banner Support

### DIFF
--- a/src/add2home.js
+++ b/src/add2home.js
@@ -36,7 +36,7 @@ var addToHome = (function (w) {
 			arrow: true,				// Display the balloon arrow
 			hookOnLoad: true,			// Should we hook to onload event? (really advanced usage)
 			iOS6AppBanner: true,		// Skip the default popup and show the iOS 6 built-in Smart App Banner
-			appId: '',					// App ID defined in iTunes. Must be present if iOS6AppBanner is true
+			appId: 0,					// App ID defined in iTunes. Must be present if iOS6AppBanner is true
 			iterations: 100				// Internal/debug use
 		},
 
@@ -91,13 +91,10 @@ var addToHome = (function (w) {
 		OSVersion = OSVersion[1] ? +OSVersion[1].replace('_', '.') : 0;
 
 		if ( options.iOS6AppBanner && OSVersion >= 6 && parseInt( options.appId ) > 0 ) {
-			console.log(options.iOS6AppBanner);
-			console.log(OSVersion);
 			var appBannerMetaTag = document.createElement( 'meta' );
 			appBannerMetaTag.setAttribute( 'name', 'apple-itunes-app' );
 			appBannerMetaTag.setAttribute( 'content', 'app-id=' + options.appId );
 			document.getElementsByTagName( 'head' )[0].appendChild( appBannerMetaTag );
-			console.log(appBannerMetaTag);
 		} else {
 			lastVisit = +w.localStorage.getItem('addToHome');
 


### PR DESCRIPTION
**Summary:**
I have also used this awesome script to advertise the actual App Store version of the app by including a link in the message. With the introduction of iOS 6 and Smart App Banners, I wanted to switch to using that functionality where possible. This change allows a boolean to be set triggering the Smart App Banner, and specifying an app ID to link to. 

**New Options:**
- `options.iOS6AppBanner:` True if you want iOS 6 devices to show the app banner. Defaults to true.
- `options.appId:` The numerical app ID as defined in the iTunes store. If iOS6AppBanner is true but this is not set, no app banner will be displayed.

**Directions:**
1. When specifying the initial options for use in addToHomeConfig, also specify something similar to the following:

```
ios6AppBanner: true,
appId: 546236058
```
1. That's it! :)
