### PR TITLE
Override options on manualShow

### DIFF
--- a/src/add2home.js
+++ b/src/add2home.js
@@ -226,10 +226,16 @@ var addToHome = (function (w) {
 		closeTimeout = setTimeout(close, options.lifespan);
 	}
 
-	function manualShow (override) {
+	function manualShow (override, opt) {
 		if ( !isIDevice || balloon ) return;
 
 		overrideChecks = override;
+		// Merge local with global options
+		if (opt) {
+			for ( i in opt ) {
+				options[i] = opt[i];
+			}
+		}
 		loaded();
 	}
 


### PR DESCRIPTION
Allow to override options when manual show.

Sometimes you can't or don't want to specify addToHomeConfig before the script loads. This will allow the user to change the options on manual show.
