### PR TITLE
Escaped the touchIcon href

### DIFF
--- a/src/add2home.js
+++ b/src/add2home.js
@@ -290,8 +290,10 @@ var addToHome = (function (w) {
 
 
 	function clicked () {
-		w.sessionStorage.setItem('addToHomeSession', '1');
-		isSessionActive = true;
+		try {
+			w.sessionStorage.setItem('addToHomeSession', '1');
+			isSessionActive = true;
+		} catch (error) {}
 		close();
 	}
 


### PR DESCRIPTION
The server I've been given to work on has all sorts of weird characters in the URL. I've got no control over that and it was causing the touch icon to not display.

This fix simply adds quotes around the touch icon href so the image now loads correctly.
