### PR TITLE
Fix android language detection

### DIFF
--- a/src/addtohomescreen.js
+++ b/src/addtohomescreen.js
@@ -107,7 +107,7 @@ _extend(ath, {
 	language: _nav.language && _nav.language.toLowerCase().replace('-', '_') || ''
 });
 
-// normalize language string so it always looks like aa_bb
+// search for matching language if browser only provide 2 letter language code
 if ( ath.language.length == 2 ) {
 	for (var languageKey in ath.intl) {
 		if (languageKey.substring(0, 2) == ath.language) {


### PR DESCRIPTION
While working on translations I discovered an issue with language detection on android. For example on a device with Norwegian language selected:

iOS: navigator.language is 'nb-no' which is normalized to nb_no
Android: navigator.language is 'nb'  which is normalized to nb_nb

This pull request suggests an alternative solution where available languages are searched for matching starting letters and the first match is used. You can probably implement this more elegantly yourself, but at least it should work as a proof of concept.
