### PR TITLE
Patch for <IE9 browsers

### DIFF
--- a/src/addtohomescreen.js
+++ b/src/addtohomescreen.js
@@ -8,6 +8,11 @@
                               by Matteo Spinelli ~ http://cubiq.org
 */
 
+// Check for addEventListener browser support (<IE9), otherwise return preventing useless overhead 
+if ( !window.addEventListener ) {
+	return;
+}
+
 // Check if document is loaded, needed by autostart
 var _DOMReady = false;
 if ( document.readyState === 'complete' ) {


### PR DESCRIPTION
When addtohomescreen.js is used in bundle with other javascript files for web applications also supporting <IE9 browsers, it will throw an exception due to "addEventListener" not being supported, blocking following code execution. This patch will also prevent useless overhead since those browsers are not mobile capable.
