### PR TITLE
Fix issue where JSON.parse(undefined) throws exception

### DIFF
--- a/src/addtohomescreen.js
+++ b/src/addtohomescreen.js
@@ -181,12 +181,8 @@ ath.Class = function (options) {
 	this.container = document.documentElement;
 
 	// load session
-	var sessionData = localStorage.getItem(this.options.appID);
-	if (sessionData !== undefined) {
-		this.session = JSON.parse(sessionData);
-	}
-	
-	this.session = this.session || _defaultSession;
+	this.session = localStorage.getItem(this.options.appID);
+	this.session = this.session ? JSON.parse(this.session) : undefined;
 
 	// user most likely came from a direct link containing our token, we don't need it and we remove it
 	if ( ath.hasToken && ( !ath.isCompatible || !this.session ) ) {
@@ -198,6 +194,8 @@ ath.Class = function (options) {
 	if ( !ath.isCompatible ) {
 		return;
 	}
+	
+	this.session = this.session || _defaultSession;
 
 	// check if we can use the local storage
 	try {


### PR DESCRIPTION
Hi,

I observed an error "unexpected token u" on an embedded Android WebView, searched around a little, and discovered `JSON.parse` with `undefined` can cause this issue on some browsers: http://stackoverflow.com/a/13022566

A really simple fix by not parsing the session data if it's not defined, then falling back to the default session as before.

Thanks for this great library!
