### PR TITLE
Differentiate between the WebView and Chrome for Android

### DIFF
--- a/src/addtohomescreen.js
+++ b/src/addtohomescreen.js
@@ -142,7 +142,7 @@ _extend(ath, {
 	hasToken: document.location.hash == '#ath' || _reSmartURL.test(document.location.href) || _reQueryString.test(document.location.search),
 	isRetina: window.devicePixelRatio && window.devicePixelRatio > 1,
 	isIDevice: (/iphone|ipod|ipad/i).test(_ua),
-	isMobileChrome: _ua.indexOf('Android') > -1 && (/Chrome\/[.0-9]*/).test(_ua),
+	isMobileChrome: _ua.indexOf('Android') > -1 && (/Chrome\/[.0-9]*/).test(_ua) && _ua.indexOf("Version") == -1,
 	isMobileIE: _ua.indexOf('Windows Phone') > -1,
 	language: _nav.language && _nav.language.toLowerCase().replace('-', '_') || ''
 });


### PR DESCRIPTION
Hi, I am sorry for the previous error. I fixed it and this is a new pull request.

I had problems with some stock android browsers that use chrome webview. That browsers doesn' t have the add to homescreen feature. I checked chrome documentation and you can differentiate chrome and chrome webviews searching the "Version" string in the user agent. You can confirm it checking the following page https://developer.chrome.com/multidevice/user-agent#webview_user_agent

I hope this helps, and thank you for sharing your project.

Regards,
Juan

