### PR TITLE
Prevent exception with localStorage.getItem

### DIFF
--- a/src/addtohomescreen.js
+++ b/src/addtohomescreen.js
@@ -177,6 +177,14 @@ ath.removeSession = function (appID) {
 	}
 };
 
+ath.getItem = function(item) {
+  try {
+    localStorage.getItem(item);
+  } catch(e) {
+    // Preventing exception for some browsers when fetching localStorage key
+  }
+};
+
 ath.Class = function (options) {
 	// merge default options with user config
 	this.options = _extend({}, ath.defaults);
@@ -206,7 +214,7 @@ ath.Class = function (options) {
 	this.container = document.documentElement;
 
 	// load session
-	this.session = localStorage.getItem(this.options.appID);
+	this.session = ath.getItem(this.options.appID);
 	this.session = this.session ? JSON.parse(this.session) : undefined;
 
 	// user most likely came from a direct link containing our token, we don't need it and we remove it
@@ -245,7 +253,7 @@ ath.Class = function (options) {
 	}
 
 	// check compatibility with old versions of add to homescreen. Opt-out if an old session is found
-	if ( localStorage.getItem('addToHome') ) {
+	if ( ath.getItem('addToHome') ) {
 		this.optOut();
 	}
 

--- a/src/addtohomescreen.js
+++ b/src/addtohomescreen.js
@@ -177,14 +177,6 @@ ath.removeSession = function (appID) {
 	}
 };
 
-ath.getItem = function(item) {
-  try {
-    localStorage.getItem(item);
-  } catch(e) {
-    // Preventing exception for some browsers when fetching localStorage key
-  }
-};
-
 ath.Class = function (options) {
 	// merge default options with user config
 	this.options = _extend({}, ath.defaults);
@@ -214,7 +206,7 @@ ath.Class = function (options) {
 	this.container = document.documentElement;
 
 	// load session
-	this.session = ath.getItem(this.options.appID);
+	this.session = this.getItem(this.options.appID);
 	this.session = this.session ? JSON.parse(this.session) : undefined;
 
 	// user most likely came from a direct link containing our token, we don't need it and we remove it
@@ -253,7 +245,7 @@ ath.Class = function (options) {
 	}
 
 	// check compatibility with old versions of add to homescreen. Opt-out if an old session is found
-	if ( ath.getItem('addToHome') ) {
+	if ( this.getItem('addToHome') ) {
 		this.optOut();
 	}
 
@@ -587,6 +579,14 @@ ath.Class.prototype = {
 		this.session = _defaultSession;
 		this.updateSession();
 	},
+
+  getItem: function(item) {
+    try {
+      return localStorage.getItem(item);
+    } catch(e) {
+      // Preventing exception for some browsers when fetching localStorage key
+    }
+  },
 
 	optOut: function () {
 		this.session.optedout = true;

--- a/src/addtohomescreen.js
+++ b/src/addtohomescreen.js
@@ -585,6 +585,7 @@ ath.Class.prototype = {
       return localStorage.getItem(item);
     } catch(e) {
       // Preventing exception for some browsers when fetching localStorage key
+      ath.hasLocalStorage = false;
     }
   },
 


### PR DESCRIPTION
On our production application, Honeybadger reported some clients are experiencing an exception with `localStorage.getItem` in this script. This fixes that.