### PR TITLE
Fixed markup replacement

### DIFF
--- a/src/addtohomescreen.js
+++ b/src/addtohomescreen.js
@@ -256,7 +256,7 @@ ath.Class = function (options) {
 	}
 
 	// the element the message will be appended to
-	this.container = document.documentElement;
+	this.container = document.body;
 
 	// load session
 	this.session = this.getItem(this.options.appID);


### PR DESCRIPTION
Hi,

I have created this fix, because in the current version the components puts the markup directly into the *html* element and not into the *body* element.