### PR TITLE
Remove reset stuff from addtohomescreen.css

### DIFF
--- a/style/addtohomescreen.css
+++ b/style/addtohomescreen.css
@@ -1,9 +1,3 @@
-.ath-viewport * {
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing: border-box;
-	box-sizing: border-box;
-}
-
 .ath-viewport {
 	position: relative;
 	z-index: 2147483641;


### PR DESCRIPTION
This should not be included, this should be users own problem to add reset stuff to their own css. This could possibly cause problems for other who import the css file.