### PR TITLE
Move this.container assignment to DOM append logic

### DIFF
--- a/src/addtohomescreen.js
+++ b/src/addtohomescreen.js
@@ -275,9 +275,6 @@ ath.Class = function (options) {
 		ath.OSVersion = ath.OS == 'ios' ? '8' : '4';
 	}
 
-	// the element the message will be appended to
-	this.container = document.body;
-
 	// load session
 	this.session = this.getItem(this.options.appID);
 	this.session = this.session ? JSON.parse(this.session) : undefined;
@@ -549,6 +546,7 @@ ath.Class.prototype = {
 		this.viewport.style.left = '-99999em';
 
 		// attach all elements to the DOM
+		this.container = document.body;
 		this.viewport.appendChild(this.element);
 		this.container.appendChild(this.viewport);
 


### PR DESCRIPTION
I was having problems with getting the popup to show up at all and hacking around in the console, (by deleting local storage, setting `shown` to be false, reinstantiating the object etc.) it was clear that `this.container` in the `ath.Class` function for some reason was not setting `this.container` correctly, and so, when it came to appending the viewport node to the container I was getting a `null` error. 

Looking around it seemed to make more sense to assign `this.container` in the same part of the code as the other DOM appending actions and doing this did in fact fix my problem; the popup now shows up for me as expected and behaves correctly. 

I'm not sure quite why this was happening in the first place, but it seems to me that if it doesn't have any other impact elsewhere (I can't see that it does) it makes sense to just define the container along with the `element` and `viewport` nodes, like so...
