### PR TITLE
addToHomeScreen must be called from within the <body>

### DIFF
--- a/demos/add-event/index.html
+++ b/demos/add-event/index.html
@@ -15,6 +15,9 @@
 
 <link rel="stylesheet" type="text/css" href="../../style/addtohomescreen.css">
 <script src="../../src/addtohomescreen.js"></script>
+</head>
+
+<body>
 <script>
 var a = addToHomescreen({
 	onAdd: function () {
@@ -22,9 +25,6 @@ var a = addToHomescreen({
 	}
 });
 </script>
-</head>
-
-<body>
 <p>This demo shows how to add a custom event fired the first time (and the first time only) you run the application from the homescreen.</p>
 
 <p>Add this page to the homescreen and then run the app from there.</p>

--- a/demos/detect-homescreen/index.html
+++ b/demos/detect-homescreen/index.html
@@ -12,14 +12,14 @@
 
 <link rel="stylesheet" type="text/css" href="../../style/addtohomescreen.css">
 <script src="../../src/addtohomescreen.js"></script>
+</head>
+
+<body>
 <script>
 addToHomescreen({
     detectHomescreen: true
 });
 </script>
-</head>
-
-<body>
 <p>This demo tries to detect when the application is added to the homescreen by using a #hash token. You can also use a query string or a smart URL, but they are all guesstimate and there's a 20-30% chances of false positives. The good news is that false negative (ie: the call out being displayed when the app has been already added to the homescreen) should be very rare.</p>
 <p>Remember that the only 100% safe way to use the add to homescreen feature is by using the <strong>apple-mobile-web-app-capable</strong> meta tag.</p>
 </body>

--- a/demos/simple/index.html
+++ b/demos/simple/index.html
@@ -22,11 +22,11 @@
 
 <link rel="stylesheet" type="text/css" href="../../style/addtohomescreen.css">
 <script src="../../src/addtohomescreen.js"></script>
-<script>
-addToHomescreen();
-</script>
 </head>
 
 <body>
+<script>
+addToHomescreen();
+</script>
 </body>
 </html>

--- a/demos/stock-android/index.html
+++ b/demos/stock-android/index.html
@@ -93,6 +93,9 @@
 	background-size: auto 100%;
 }
 </style>
+</head>
+
+<body>
 <script>
 var _ath = addToHomescreen;
 
@@ -122,8 +125,5 @@ _ath({
 </script>
 <!-- ************************* END HERE ************************* -->
 
-</head>
-
-<body>
 </body>
 </html>


### PR DESCRIPTION
I was having trouble getting ATH to work because of an error. I discovered that in order to reference document.body as the container, the script must be within the <body> tag.

Some of the demos reflect this, but not all of them do. I've updated the demos to reflect this.